### PR TITLE
Fix: Recreate disconnected connections when being retrieved

### DIFF
--- a/src/ConnectionManager.php
+++ b/src/ConnectionManager.php
@@ -60,6 +60,12 @@ class ConnectionManager
             $name = $this->defaultConnection;
         }
 
+        // Remove the connection if it is in a disconnected state.
+        // Doing this instead of simply reconnecting ensures the caller will get a fresh connection.
+        if (array_key_exists($name, $this->connections) && !$this->connections[$name]->isConnected()) {
+            unset($this->connections[$name]);
+        }
+
         if (!array_key_exists($name, $this->connections)) {
             $this->connections[$name] = $this->createConnection($name);
         }


### PR DESCRIPTION
This PR addresses the problem described in #18 where manually closing a connection will not remove the connection from the `ConnectionManager`:
```php
// First job
$mqtt = MQTT::connection(); // connected
$mqtt->publish($topic, $data, $qos);
$mqtt->disconnect();

// nth job
$mqtt = MQTT::connection(); // disconnected
```

As a solution to this problem, we simply reinitialize the connection on retrieval. Another option would be to reconnect using the old instance, but this approach will always yield a fresh instance.

**Known issues:**
`$mqtt->isConnected()` will not detect connection loss based on closed sockets, socket timeouts and similar. To do so, we would need to ping the MQTT broker, which is currently not easily possible due to the way data is sent and received. Imagine the following scenario:
```php
// First job
$mqtt = MQTT::connection(); // connected
$mqtt->subscribe($topic, $callback);

// nth job
$mqtt = MQTT::connection(); // connected

// Cannot send PINGREQ and wait for PINGRESP because the socket may have published messages
// from the subscription waiting
$mqtt->isConnected();
```