### PR TITLE
Add Dependabot and improve build pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    allow:
+      - dependency-type: "development"
+    schedule:
+      interval: "daily"
+      time: "05:00"
+      timezone: "Europe/Vienna"
+    labels:
+      - "composer dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Vienna"
+    labels:
+      - "github actions"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,9 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.4', '8.0', '8.1']
+        include:
+          - php-version: '8.1'
+            run-sonarqube-analysis: true
 
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +44,7 @@ jobs:
           echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -55,7 +58,7 @@ jobs:
 
       - name: Run SonarQube analysis
         uses: sonarsource/sonarcloud-github-action@master
-        if: matrix.php-version == '8.1'
+        if: matrix.run-sonarqube-analysis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}


### PR DESCRIPTION
This PR enables Dependabot for this repository and improves the build pipeline slightly by updating to `actions/cache@v3` and using a build variable in favour of an in-step conditional on the PHP version.