### PR TITLE
Fix: Test pipeline uses pull_request_target to allow external builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
Based on [this article](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks), we nowadays have to use `pull_request_target` to use the build pipeline of the PR target in order to receive access to the `secrets`, which are needed for the SonarQube analysis for example.