### PR TITLE
GitHub Actions: Run tests against PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1']
+        php-version: ['7.4', '8.0', '8.1', '8.2']
         include:
-          - php-version: '8.1'
+          - php-version: '8.2'
             run-sonarqube-analysis: true
 
     steps:


### PR DESCRIPTION
This PR adds PHP 8.2 to the build targets.