### PR TITLE
Update minimum php-mqtt/client version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.4|^8.0",
         "illuminate/config": "^7.0|^8.0|^9.0|^10.0",
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
-        "php-mqtt/client": "^1.0"
+        "php-mqtt/client": "^1.3.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.5"


### PR DESCRIPTION
Versions before 1.3.0 don't have setReconnectAutomatically

Fixes an exception if you have a previous version of the client installed and locked in composer.lock as the laravel-client doesn't require the updated version