### PR TITLE
Allow broadcasting to a specific log channel

### DIFF
--- a/config/mqtt-client.php
+++ b/config/mqtt-client.php
@@ -55,7 +55,8 @@ return [
             // with the log level as configured.
             'enable_logging' => env('MQTT_ENABLE_LOGGING', true),
 
-            // Which logging channel to use or to broadcast to all available
+            // Which logging channel to use for logs produced by the MQTT client.
+            // If left empty, the default log channel or stack is being used.
             'log_channel' => env('MQTT_LOG_CHANNEL', null),
 
             // Defines which repository implementation shall be used. Currently,

--- a/config/mqtt-client.php
+++ b/config/mqtt-client.php
@@ -55,6 +55,9 @@ return [
             // with the log level as configured.
             'enable_logging' => env('MQTT_ENABLE_LOGGING', true),
 
+            // Which logging channel to use or to broadcast to all available
+            'log_channel' => env('MQTT_LOG_CHANNEL', null),
+
             // Defines which repository implementation shall be used. Currently,
             // only a MemoryRepository is supported.
             'repository' => MemoryRepository::class,

--- a/src/ConnectionManager.php
+++ b/src/ConnectionManager.php
@@ -139,13 +139,13 @@ class ConnectionManager
         $cleanSession   = (bool) Arr::get($config, 'use_clean_session', true);
         $repository     = Arr::get($config, 'repository', Repository::class);
         $loggingEnabled = (bool) Arr::get($config, 'enable_logging', true);
-        $loggingChannel = (bool) Arr::get($config, 'log_channel', null);
+        $loggingChannel = Arr::get($config, 'log_channel', null);
 
         $settings   = $this->buildConnectionSettings(Arr::get($config, 'connection_settings', []));
         $repository = $this->application->make($repository);
         $logger     = $loggingEnabled ? $this->application->make('log') : null;
 			
-        if($logger && null !== $loggingChannel) {
+        if($logger && $loggingChannel) {
             $logger = $logger->channel($loggingChannel);
         }
 

--- a/src/ConnectionManager.php
+++ b/src/ConnectionManager.php
@@ -139,10 +139,15 @@ class ConnectionManager
         $cleanSession   = (bool) Arr::get($config, 'use_clean_session', true);
         $repository     = Arr::get($config, 'repository', Repository::class);
         $loggingEnabled = (bool) Arr::get($config, 'enable_logging', true);
+        $loggingChannel = (bool) Arr::get($config, 'log_channel', null);
 
         $settings   = $this->buildConnectionSettings(Arr::get($config, 'connection_settings', []));
         $repository = $this->application->make($repository);
         $logger     = $loggingEnabled ? $this->application->make('log') : null;
+			
+        if($logger && null !== $loggingChannel) {
+            $logger = $logger->channel($loggingChannel);
+        }
 
         $client = new MqttClient($host, $port, $clientId, $protocol, $repository, $logger);
         $client->connect($settings, $cleanSession);

--- a/src/ConnectionManager.php
+++ b/src/ConnectionManager.php
@@ -139,14 +139,14 @@ class ConnectionManager
         $cleanSession   = (bool) Arr::get($config, 'use_clean_session', true);
         $repository     = Arr::get($config, 'repository', Repository::class);
         $loggingEnabled = (bool) Arr::get($config, 'enable_logging', true);
-        $loggingChannel = Arr::get($config, 'log_channel', null);
+        $logChannel     = Arr::get($config, 'log_channel', null);
 
         $settings   = $this->buildConnectionSettings(Arr::get($config, 'connection_settings', []));
         $repository = $this->application->make($repository);
         $logger     = $loggingEnabled ? $this->application->make('log') : null;
 			
-        if($logger && $loggingChannel) {
-            $logger = $logger->channel($loggingChannel);
+        if($logger && $logChannel) {
+            $logger = $logger->channel($logChannel);
         }
 
         $client = new MqttClient($host, $port, $clientId, $protocol, $repository, $logger);


### PR DESCRIPTION
Adds a new configuration option that allows overriding the log channel which is used by the MQTT client.