### PR TITLE
Add support for php-mqtt/client:^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.4|^8.0",
         "illuminate/config": "^7.0|^8.0|^9.0|^10.0",
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
-        "php-mqtt/client": "^1.3.0"
+        "php-mqtt/client": "^1.3.0|^2.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.5"


### PR DESCRIPTION
This PR adds support for `php-mqtt/client:^2.0` besides the support for `^1.3.0`. Since the v2 only includes internal changes and has been released as v2 to be conform to semver regarding object oriented programming, no changes are required.