### PR TITLE
Update supported PHP and Laravel versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2']
+        php-version: ['8.0', '8.1', '8.2']
         include:
           - php-version: '8.2'
             run-sonarqube-analysis: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.0', '8.1', '8.2']
+        php-version: ['8.0', '8.1', '8.2', '8.3']
         include:
-          - php-version: '8.2'
+          - php-version: '8.3'
             run-sonarqube-analysis: true
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "illuminate/config": "^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "php": "^8.0",
+        "illuminate/config": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0",
         "php-mqtt/client": "^1.3.0|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
The PR adds a build against PHP 8.3 and removes support for PHP 7.4 as well as Laravel versions which have reached their End of Life.