### PR TITLE
CI: Build against PHP 8.4 and raise minimum PHP version to 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
         include:
-          - php-version: '8.3'
+          - php-version: '8.4'
             run-sonarqube-analysis: true
 
     steps:
@@ -29,14 +29,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          tools: phpunit:9.5.0
           coverage: pcov
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
-      - name: Setup problem matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         }
     ],
     "require": {
-        "php": "^8.0",
         "illuminate/config": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",
+        "php": "^8.1",
         "php-mqtt/client": "^1.3.0|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
The PR adds a new build against PHP 8.4 and removes the support for PHP 8.0 which is end of life.