### PR TITLE
Add support to configure TLS ALPN via config file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4']
         include:
           - php-version: '8.4'
             run-sonarqube-analysis: true

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -36,7 +36,6 @@
     <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
     <rule ref="Generic.Formatting.MultipleStatementAlignment"/>
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
     <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
     <rule ref="Generic.Metrics.CyclomaticComplexity">
@@ -62,7 +61,6 @@
             <property name="indent" value="4"/>
         </properties>
     </rule>
-    <rule ref="MySource.PHP.EvalObjectFactory"/>
     <rule ref="PEAR.Commenting.ClassComment">
         <exclude name="PEAR.Commenting.ClassComment.MissingAuthorTag"/>
         <exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag"/>

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     "require": {
         "illuminate/config": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
-        "php": "^8.1",
-        "php-mqtt/client": "^1.3.0|^2.0"
+        "php": "^8.2",
+        "php-mqtt/client": "^2.1"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.5"

--- a/config/mqtt-client.php
+++ b/config/mqtt-client.php
@@ -78,6 +78,7 @@ return [
                     'client_certificate_file' => env('MQTT_TLS_CLIENT_CERT_FILE'),
                     'client_certificate_key_file' => env('MQTT_TLS_CLIENT_CERT_KEY_FILE'),
                     'client_certificate_key_passphrase' => env('MQTT_TLS_CLIENT_CERT_KEY_PASSPHRASE'),
+                    'alpn' => env('MQTT_TLS_ALPN'),
                 ],
 
                 // Credentials used for authentication and authorization.

--- a/src/ConnectionManager.php
+++ b/src/ConnectionManager.php
@@ -179,6 +179,7 @@ class ConnectionManager
             ->setTlsClientCertificateFile(Arr::get($config, 'tls.client_certificate_file'))
             ->setTlsClientCertificateKeyFile(Arr::get($config, 'tls.client_certificate_key_file'))
             ->setTlsClientCertificateKeyPassphrase(Arr::get($config, 'tls.client_certificate_key_passphrase'))
+            ->setTlsAlpn(Arr::get($config, 'tls.alpn'))
             ->setLastWillTopic(Arr::get($config, 'last_will.topic'))
             ->setLastWillMessage(Arr::get($config, 'last_will.message'))
             ->setLastWillQualityOfService((int) Arr::get($config, 'last_will.quality_of_service', MqttClient::QOS_AT_MOST_ONCE))


### PR DESCRIPTION
As requested in #77, this PR adds support to configure the TLS ALPN in the config file. It is the one configuration setting that has not been supported by the Laravel client yet.

Because this setting was only introduced in the `php-mqtt/client` v2.1.0, the required version of the client was bumped. The EOL version of PHP 8.1 has also been removed from the supported versions.